### PR TITLE
Add vitest tests for MemStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -98,7 +99,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "vitest": "^1.5.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MemStorage } from '../storage';
+
+describe('MemStorage automations', () => {
+  let storage: MemStorage;
+
+  beforeEach(() => {
+    storage = new MemStorage();
+  });
+
+  it('creates and retrieves an automation', async () => {
+    const automation = await storage.createAutomation({
+      propertyCode: 'P1',
+      olxCode: 'O1',
+      status: 'pending'
+    });
+
+    expect(automation.id).toBeGreaterThan(0);
+    const fetched = await storage.getAutomation(automation.id);
+    expect(fetched).toEqual(automation);
+  });
+
+  it('returns automations sorted and limited', async () => {
+    const a1 = await storage.createAutomation({ propertyCode: 'A1', olxCode: 'O1', status: 'pending' });
+    const a2 = await storage.createAutomation({ propertyCode: 'A2', olxCode: 'O2', status: 'pending' });
+
+    const all = await storage.getAutomations();
+    expect(all[0].id).toBe(a2.id);
+    expect(all[1].id).toBe(a1.id);
+
+    const limited = await storage.getAutomations(1);
+    expect(limited).toHaveLength(1);
+    expect(limited[0].id).toBe(a2.id);
+  });
+
+  it('updates an automation', async () => {
+    const auto = await storage.createAutomation({ propertyCode: 'A', olxCode: 'O', status: 'pending' });
+    const updated = await storage.updateAutomation(auto.id, { status: 'completed', progress: 100 });
+    expect(updated?.status).toBe('completed');
+    expect(updated?.progress).toBe(100);
+
+    const fetched = await storage.getAutomation(auto.id);
+    expect(fetched?.status).toBe('completed');
+  });
+
+  it('deletes an automation', async () => {
+    const auto = await storage.createAutomation({ propertyCode: 'A', olxCode: 'O', status: 'pending' });
+    const removed = await storage.deleteAutomation(auto.id);
+    expect(removed).toBe(true);
+    const fetched = await storage.getAutomation(auto.id);
+    expect(fetched).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add `test` script using `vitest`
- include `vitest` as a dev dependency
- create `server/__tests__/storage.test.ts` covering basic MemStorage behavior

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843926b4dd48328bf4fa535d34db6a0