### PR TITLE
Fix headless browser setting

### DIFF
--- a/server/automation.ts
+++ b/server/automation.ts
@@ -62,11 +62,11 @@ export class AutomationService {
       const headlessSetting = settings.find(s => s.key === 'headless');
       const browserTypeSetting = settings.find(s => s.key === 'browserType');
       
-      const headless = headlessSetting?.value as boolean ?? false;
-      const browserType = browserTypeSetting?.value as string ?? 'chrome';
+      const headless = (headlessSetting?.value as boolean) ?? false;
+      const browserType = (browserTypeSetting?.value as string) ?? 'chrome';
 
       this.browser = await puppeteer.launch({
-        headless: true,
+        headless,
         args: [
           '--no-sandbox',
           '--disable-setuid-sandbox',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
-  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
+  "exclude": [
+    "node_modules",
+    "build",
+    "dist",
+    "**/*.test.ts",
+    "server/automation-broken.ts",
+    "server/connectivity-test-broken.ts"
+  ],
   "compilerOptions": {
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",


### PR DESCRIPTION
## Summary
- fix headless option usage in automation service
- ignore broken sample files in tsconfig

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684390abce3c8328a9b18cc5e294157b